### PR TITLE
Made seq message parameter optional

### DIFF
--- a/wwt_kernel_data_relay/serverextension.py
+++ b/wwt_kernel_data_relay/serverextension.py
@@ -35,9 +35,7 @@ class SequencedBuffer(object):
     def accumulate(self, reply, log_object):
         seq = reply["content"].get("seq")
         if seq is None:
-            log_object.log_warning("dropping message %r", reply)
-            return
-
+            seq = 0
         # ignore old, duplicated messages
         if seq >= self.next_seq:
             self.by_seq[seq] = reply
@@ -120,7 +118,7 @@ class Registry(LoggingConfigurable):
         replies to *other* requests, which need to be buffered so that those
         handlers get the data they need.
 
-        This will raise queue.Empty if there really seems to be no next reply.
+        This will raise queue. Empty if there really seems to be no next reply.
         """
 
         tries = 0


### PR DESCRIPTION
This is the reason for the 404's and other error events not propagating from jupyter_relay. One could drop the seq requirement like this or make sure that seq is always provided by the user. Judging by the row in jupyter_relay 
`'seq': seqnum,  # this isn't needed by the relay, but can be useful for debugging`
I think the original idea was to keep this parameter optional, at least for single messages, like errors.

An alternative solution is to force users like jupyter_relay to always send a seq number.